### PR TITLE
Bugfix/payment info

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
This pull request was necessary to correct a mistake in the def create section of paymenttype view. The create_date and expiration_date properties were referencing the incorrect keys within the request.

## Changes

I set the value of the create_date property to request.data["create_date"] and the value of the expiration_date property to request.data["expiration_date"] 

**Request**

POST `/paymenttypes` Creates a new paymenttype

```json

   {
    "merchant_name": "Snail",
    "account_number": "7658492037",
    "expiration_date": "2026-11-21",
    "create_date": "2024-03-28"
}

```

**Response**

HTTP/1.1 201 Created

```json
{
    "id": 12,
    "url": "http://localhost:8000/paymenttypes/12",
    "merchant_name": "Snail",
    "account_number": "7658492037",
    "expiration_date": "2026-11-21",
    "create_date": "2024-03-28"
}
```

## Testing

To test this run you python debugger and then open postman. Enter the url http://localhost:8000/paymenttypes and set the request type to post. Add the example json above in the body of the request. After sending the request you should see the the expiration date and create_date have not been switched.


## Related Issues
- This addresses the server side for issue ticket #28 changes on the front end to follow.