### PR TITLE
Bug: Incorrect result for minimum products sold #30

### DIFF
--- a/bangazonapi/fixtures/order_product.json
+++ b/bangazonapi/fixtures/order_product.json
@@ -78,5 +78,165 @@
             "order_id": 3,
             "product_id": 45
         }
-    }
+    },
+    {
+        "model": "bangazonapi.orderproduct",
+        "pk": 10,
+        "fields": {
+          "order_id": 4,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 11,
+        "fields": {
+          "order_id": 4,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 12,
+        "fields": {
+          "order_id": 5,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 13,
+        "fields": {
+          "order_id": 5,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 14,
+        "fields": {
+          "order_id": 6,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 15,
+        "fields": {
+          "order_id": 6,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 16,
+        "fields": {
+          "order_id": 7,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 17,
+        "fields": {
+          "order_id": 7,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 18,
+        "fields": {
+          "order_id": 1,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 19,
+        "fields": {
+          "order_id": 1,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 20,
+        "fields": {
+          "order_id": 4,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 21,
+        "fields": {
+          "order_id": 4,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 22,
+        "fields": {
+          "order_id": 5,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 23,
+        "fields": {
+          "order_id": 5,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 24,
+        "fields": {
+          "order_id": 6,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 25,
+        "fields": {
+          "order_id": 6,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 26,
+        "fields": {
+          "order_id": 7,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 27,
+        "fields": {
+          "order_id": 7,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 28,
+        "fields": {
+          "order_id": 1,
+          "product_id": 50
+        }
+      },
+      {
+        "model": "bangazonapi.orderproduct",
+        "pk": 29,
+        "fields": {
+          "order_id": 3,
+          "product_id": 50
+        }
+      }
 ]

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -1,4 +1,5 @@
 """View module for handling requests about products"""
+
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation
 import base64
@@ -15,16 +16,28 @@ from rest_framework.parsers import MultiPartParser, FormParser
 
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+        fields = (
+            "id",
+            "name",
+            "price",
+            "number_sold",
+            "description",
+            "quantity",
+            "created_date",
+            "location",
+            "image_path",
+            "average_rating",
+            "can_be_rated",
+        )
         depth = 1
 
 
 class Products(ViewSet):
     """Request handlers for Products in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request):
@@ -98,16 +111,18 @@ class Products(ViewSet):
         new_product.category = product_category
 
         if "image_path" in request.data:
-            format, imgstr = request.data["image_path"].split(';base64,')
-            ext = format.split('/')[-1]
-            data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
+            format, imgstr = request.data["image_path"].split(";base64,")
+            ext = format.split("/")[-1]
+            data = ContentFile(
+                base64.b64decode(imgstr),
+                name=f'{new_product.id}-{request.data["name"]}.{ext}',
+            )
 
             new_product.image_path = data
 
         new_product.save()
 
-        serializer = ProductSerializer(
-            new_product, context={'request': request})
+        serializer = ProductSerializer(new_product, context={"request": request})
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -152,7 +167,7 @@ class Products(ViewSet):
         """
         try:
             product = Product.objects.get(pk=pk)
-            serializer = ProductSerializer(product, context={'request': request})
+            serializer = ProductSerializer(product, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
@@ -209,10 +224,12 @@ class Products(ViewSet):
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except Product.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     def list(self, request):
         """
@@ -245,18 +262,18 @@ class Products(ViewSet):
         products = Product.objects.all()
 
         # Support filtering by category and/or quantity
-        category = self.request.query_params.get('category', None)
-        quantity = self.request.query_params.get('quantity', None)
-        order = self.request.query_params.get('order_by', None)
-        direction = self.request.query_params.get('direction', None)
-        number_sold = self.request.query_params.get('number_sold', None)
+        category = self.request.query_params.get("category", None)
+        quantity = self.request.query_params.get("quantity", None)
+        order = self.request.query_params.get("order_by", None)
+        direction = self.request.query_params.get("direction", None)
+        number_sold = self.request.query_params.get("number_sold", None)
 
         if order is not None:
             order_filter = order
 
             if direction is not None:
                 if direction == "desc":
-                    order_filter = f'-{order}'
+                    order_filter = f"-{order}"
 
             products = products.order_by(order_filter)
 
@@ -264,21 +281,23 @@ class Products(ViewSet):
             products = products.filter(category__id=category)
 
         if quantity is not None:
-            products = products.order_by("-created_date")[:int(quantity)]
+            products = products.order_by("-created_date")[: int(quantity)]
 
         if number_sold is not None:
+
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 
             products = filter(sold_filter, products)
 
         serializer = ProductSerializer(
-            products, many=True, context={'request': request})
+            products, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
-    @action(methods=['post'], detail=True)
+    @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
         """Recommend products to other users"""
 


### PR DESCRIPTION
Ticket #30

Previously when making a request via Postman, all of the products would appear in the return regardless of the number_sold inputted in the url. I have updated the codebase so that correct products return based on the number_sold specified in the url.

## Changes

- In the views/product.py module, I updated the conditional in sold_filter definition to return True if the product number sold is greater than or equal to the specified number_sold in the url. (line 289)
- I also updated the order_product.json fixture to include more data
- **You will need to execute the ./seed_data.sh command if you wish to seed this new data into your local database. 

## Testing

Description of how to test code...

- [ ] If you wish to seed your database with the new data, run the ./seed_data.sh command in your terminal
- [ ] Check your order_product.json fixture to ensure the new data has imported. You should have 29 items total.
- [ ] start your debugger
- [ ] In postman, make the following GET request: http://localhost:8000/products?number_sold=20
- [ ] You should get a response with a 200 code
- [ ] You can also verify that this is working in the client webpage by navigating to the product page and filtering the products by the number sold. 

## Responses

If you have seeded the new data into your database, you should see the following response in Postman: 

```json
[
    {
        "id": 50,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 22,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Berlin",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 3.25
    }
]
```
If you have not seeded the new data into your database, you will only see an empty array because none of the orders have more than 20 sold. 

## Related Tickets

#37