### PR TITLE
Update Order with Payment Type

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer shopping cart"""
+
 import datetime
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -25,7 +26,8 @@ class Cart(ViewSet):
 
         try:
             open_order = Order.objects.get(
-                customer=current_user, payment_type__isnull=True)
+                customer=current_user, payment_type__isnull=True
+            )
         except Order.DoesNotExist as ex:
             open_order = Order()
             open_order.created_date = datetime.datetime.now()
@@ -39,7 +41,6 @@ class Cart(ViewSet):
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-
     def destroy(self, request, pk=None):
         """
         @api {DELETE} /cart/:id DELETE line item from cart
@@ -51,17 +52,12 @@ class Cart(ViewSet):
             HTTP/1.1 204 No Content
         """
         current_user = Customer.objects.get(user=request.auth.user)
-        open_order = Order.objects.get(
-            customer=current_user, payment_type=None)
+        open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-        line_item = OrderProduct.objects.filter(
-            product__id=pk,
-            order=open_order
-        )[0]
+        line_item = OrderProduct.objects.filter(product__id=pk, order=open_order)[0]
         line_item.delete()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
-
 
     def list(self, request):
         """
@@ -109,25 +105,23 @@ class Cart(ViewSet):
         """
         current_user = Customer.objects.get(user=request.auth.user)
         try:
-            open_order = Order.objects.get(
-                customer=current_user, payment_type=None)
+            open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-            products_on_order = Product.objects.filter(
-                lineitems__order=open_order)
+            products_on_order = Product.objects.filter(lineitems__order=open_order)
 
             serialized_order = OrderSerializer(
-                open_order, many=False, context={'request': request})
+                open_order, many=False, context={"request": request}
+            )
 
             product_list = ProductSerializer(
-                products_on_order, many=True, context={'request': request})
+                products_on_order, many=True, context={"request": request}
+            )
 
-            final = {
-                "order": serialized_order.data
-            }
+            final = {"order": serialized_order.data}
             final["order"]["products"] = product_list.data
             final["order"]["size"] = len(products_on_order)
 
         except Order.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(final["order"])

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer order"""
+
 import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
@@ -11,18 +12,18 @@ from .product import ProductSerializer
 
 
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
+    """JSON serializer for line items"""
 
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
+            view_name="lineitem", lookup_field="id"
         )
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
+
 
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
@@ -31,11 +32,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Order
-        url = serializers.HyperlinkedIdentityField(
-            view_name='order',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
+        fields = ("id", "url", "created_date", "payment_type", "customer", "lineitems")
 
 
 class Orders(ViewSet):
@@ -65,18 +63,21 @@ class Orders(ViewSet):
                 "created_date": "2019-08-16",
                 "payment_type": "http://localhost:8000/paymenttypes/1",
                 "customer": "http://localhost:8000/customers/5"
+
             }
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order = Order.objects.get(pk=pk, customer=customer)
-            serializer = OrderSerializer(order, context={'request': request})
+            serializer = OrderSerializer(order, context={"request": request})
             return Response(serializer.data)
 
         except Order.DoesNotExist as ex:
             return Response(
-                {'message': 'The requested order does not exist, or you do not have permission to access it.'},
-                status=status.HTTP_404_NOT_FOUND
+                {
+                    "message": "The requested order does not exist, or you do not have permission to access it."
+                },
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         except Exception as ex:
@@ -142,11 +143,10 @@ class Orders(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         orders = Order.objects.filter(customer=customer)
 
-        payment = self.request.query_params.get('payment_id', None)
+        payment = self.request.query_params.get("payment_id", None)
         if payment is not None:
             orders = orders.filter(payment__id=payment)
 
-        json_orders = OrderSerializer(
-            orders, many=True, context={'request': request})
+        json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -105,7 +105,9 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        payment_id = request.data["payment_type"]
+        payment_instance = Payment(pk=payment_id)
+        order.payment_type = payment_instance
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -191,7 +191,6 @@ class Profile(ViewSet):
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -242,7 +242,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -242,7 +242,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
This bug fix updates the order PUT method that allows users to add a payment method to their order.

Previously, sending a PUT request to orders/{order_id} with `{"payment_type": {payment_id}}` would trigger a 500 response. Now, sending the PUT request above receives an empty object and 204 response, as expected, and the relevant order entry in db.sqlite3 is updated with the correct payment id. 

Addresses part of the server side functionality for NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#4
(Client side changes, and possibly additional server side changes, will be needed to fully address the above-linked ticket.)

## Changes

- In views/order.py, added lines 107-109. Instantiated a new Payment() using the payment id sent in the request, and added this to the Order instance. 
```javascript
        payment_id = request.data["payment_type"]
        payment_instance = Payment(pk=payment_id)
        order.payment_type = payment_instance
```

## Testing

1. Go to the Order table and find an order with a payment_type of NULL
2. Go to the Payment table and identify a payment_id associated with the customer_id listed on the order from step 1.
3. Send the request described below in Postman. Put the order id from step 1 in the URL, and put the payment id from step 2 in the request body. You should receive a 204 response and an empty object {}.
4. Then, check the Orders table in db.sqlite3 to ensure the payment id you sent in the request has now been added to the order.

**Request**

PUT `/orders/{order_id}` Updates the payment type for an open order.

```json
{
    "payment_type": {payment_id}
}
```

**Response**

HTTP/1.1 204 No Content

```json
{}
```


## Related Issues

- Partially addresses server-side functionality for NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#4