### PR TITLE
Bugs duplicate cart items

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer shopping cart"""
+
 import datetime
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -25,7 +26,8 @@ class Cart(ViewSet):
 
         try:
             open_order = Order.objects.get(
-                customer=current_user, payment_type__isnull=True)
+                customer=current_user, payment_type__isnull=True
+            )
         except Order.DoesNotExist as ex:
             open_order = Order()
             open_order.created_date = datetime.datetime.now()
@@ -39,7 +41,6 @@ class Cart(ViewSet):
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-
     def destroy(self, request, pk=None):
         """
         @api {DELETE} /cart/:id DELETE line item from cart
@@ -51,17 +52,12 @@ class Cart(ViewSet):
             HTTP/1.1 204 No Content
         """
         current_user = Customer.objects.get(user=request.auth.user)
-        open_order = Order.objects.get(
-            customer=current_user, payment_type=None)
+        open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-        line_item = OrderProduct.objects.filter(
-            product__id=pk,
-            order=open_order
-        )[0]
+        line_item = OrderProduct.objects.filter(product__id=pk, order=open_order)[0]
         line_item.delete()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
-
 
     def list(self, request):
         """
@@ -109,25 +105,23 @@ class Cart(ViewSet):
         """
         current_user = Customer.objects.get(user=request.auth.user)
         try:
-            open_order = Order.objects.get(
-                customer=current_user, payment_type=None)
+            open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-            products_on_order = Product.objects.filter(
-                lineitems__order=open_order)
+            products_on_order = Product.objects.filter(lineitems__order=open_order)
 
             serialized_order = OrderSerializer(
-                open_order, many=False, context={'request': request})
+                open_order, many=False, context={"request": request}
+            )
 
             product_list = ProductSerializer(
-                products_on_order, many=True, context={'request': request})
+                products_on_order, many=True, context={"request": request}
+            )
 
-            final = {
-                "order": serialized_order.data
-            }
+            final = {"order": serialized_order.data}
             final["order"]["products"] = product_list.data
             final["order"]["size"] = len(products_on_order)
 
         except Order.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(final["order"])

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer order"""
+
 import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
@@ -11,18 +12,18 @@ from .product import ProductSerializer
 
 
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
+    """JSON serializer for line items"""
 
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
+            view_name="lineitem", lookup_field="id"
         )
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
+
 
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
@@ -31,11 +32,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Order
-        url = serializers.HyperlinkedIdentityField(
-            view_name='order',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
+        fields = ("id", "url", "created_date", "payment_type", "customer", "lineitems")
 
 
 class Orders(ViewSet):
@@ -65,18 +63,21 @@ class Orders(ViewSet):
                 "created_date": "2019-08-16",
                 "payment_type": "http://localhost:8000/paymenttypes/1",
                 "customer": "http://localhost:8000/customers/5"
+
             }
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order = Order.objects.get(pk=pk, customer=customer)
-            serializer = OrderSerializer(order, context={'request': request})
+            serializer = OrderSerializer(order, context={"request": request})
             return Response(serializer.data)
 
         except Order.DoesNotExist as ex:
             return Response(
-                {'message': 'The requested order does not exist, or you do not have permission to access it.'},
-                status=status.HTTP_404_NOT_FOUND
+                {
+                    "message": "The requested order does not exist, or you do not have permission to access it."
+                },
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         except Exception as ex:
@@ -142,11 +143,10 @@ class Orders(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         orders = Order.objects.filter(customer=customer)
 
-        payment = self.request.query_params.get('payment_id', None)
+        payment = self.request.query_params.get("payment_id", None)
         if payment is not None:
             orders = orders.filter(payment__id=payment)
 
-        json_orders = OrderSerializer(
-            orders, many=True, context={'request': request})
+        json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -191,7 +191,6 @@ class Profile(ViewSet):
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
This pull request addresses ticket #34, multiple items inside of the customer's cart.

The change I made was to delete the redundant line 194 in the Profile viewset.  The get request was returning a serialized response but there was also this line:

cart["order"]["line_items"] = line_items.data

Deleting this line allowed the response to only return a single line item.

## Requests / Responses
**Request**

http://localhost:8000/profile/cart


**Response**

HTTP/1.1 201 OK

{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 1
}

## Testing

Make sure to check the authorization header to ensure there is a client with a product in their cart and make a GET request using the url: 

http://localhost:8000/profile/cart

Use different authorization headers to make sure you're not getting other clients items.  You'll also get an error if you uncheck the authorization header.