### PR TITLE
Create a new order when past order is closed

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -243,7 +243,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
If a user has no open orders (i.e. their cart is emtpy) and wants to add an item to their cart, a new order will be created. 

Before this fix, items were being added to the last closed order that had already been paid for instead of being added to a new open order.

## Changes

- In views/profile.py under the /profile/cart GET method, `payment_type=None` criteria was added. This line of code now correctly defines an open order as an order that both matches the customer who submitted the request and has a payment type of None.
```javascript
open_order = Order.objects.get(customer=current_user, payment_type=None)
```

## Testing

1. In the Order table in db.sqlite3, find an order where payment_type_id is NULL. Then find the auth token that corresponds to the customer_id on that order, and use that auth token in the following requests on postman.
2. Add an item to the cart (POST request to /profile/cart)

**Request**

POST `/profile/cart` Adds a product to the cart

```json
{
    "product_id": 71
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 21,
    "product": {
        "id": 71,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "London",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }
}
```
3. Pay for the order by sending a PUT request to /orders/{orderId} that provides the payment method. See below for request and response details:

**Request**

PUT `/orders/{orderId}` Adds a payment method to an open order. Replace {orderId} with the order id from step 1. Replace {payment_id} with a payment method associated with the customer identified in step 1.

```json
{
    "payment_type": {payment_id}
}
```

**Response**

HTTP/1.1 204 OK

```json
{}
```

4. Check the Order table and verify that your order's payment_type_id no longer says NULL.
5. Repeat step 2 (add a new item to your cart with POST /profile/cart). 
6. Check the Order table again. You should see a new order with a payment_type_id of NULL. Also, check OrderProduct to verify that the product you just added has been associated with the order id just created, and has NOT been associated with the previous order id.


## Related Issues

- Addresses server side functionality of NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#33
