### PR TITLE
AK edited maximum price when creating product

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -18,7 +18,7 @@ class Product(SafeDeleteModel):
         Customer, on_delete=models.DO_NOTHING, related_name="products"
     )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],
     )
     description = models.CharField(
         max_length=255,


### PR DESCRIPTION
I have adjusted the maximum price permitted for creating a product, ensuring products above $10,000 are no longer rejected.  This modification is essential considering a significant number of cars are above $10,000. 

## Changes

- In models/product.py I adjusted the MaxValueValidator of price to 17500

## Testing

Description of how to test code...

- [ ] In the api file put a breakpoint on line 20 of models/product.py
- [ ] Step into it until the MaxValueValidator is shown in the panel
- [ ] Expand the return of MaxValueValidator to see that limit_value is 17500


## Related Issues

- Fixes #85
- Fixes #22