### PR TITLE
update product serializer

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -31,6 +31,7 @@ class ProductSerializer(serializers.ModelSerializer):
             "image_path",
             "average_rating",
             "can_be_rated",
+            "category_id"
         )
         depth = 1
 


### PR DESCRIPTION
This pull request updates the Product serializer so the client can access the 'category_id' field of each product.

## Changes

I added 'category_id' to the list of fields to be processed by the serializer.

## Requests / Responses

**Request**

Get: `/products` Lists the products

**Response**

HTTP 200 OK

example:
```json
 {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "category_id": 2
    }
```

## Testing

Run the python debugger and open Postman. Issue a GET request to http://localhost:8000/products


## Related Issues
#26