### PR TITLE
functionality to filter by name

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -269,6 +269,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
         min_price = self.request.query_params.get("min_price", None)
+        name = self.request.query_params.get("name", None)
 
         if order is not None:
             order_filter = order
@@ -296,6 +297,9 @@ class Products(ViewSet):
 
         if min_price is not None:
             products = products.filter(price__gte=min_price)
+
+        if name is not None: 
+            products = products.filter(name__icontains=name)
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
The purpose of this pull request is to support filtering the products by name. This will enable a user to enter a search term and find products whose name includes that term.

## Changes

In the product.py file, in the Views directory, I added a name variable to the list function to reference the "name" key in the request. If the value of this key is not the default (none), then the products list will be filtered to return products whose names contain the search term. 

## Requests / Responses

**Request**

GET `/products` Lists all products

```json
    {
                    "url": "http://localhost:8000/products?name=optima&",
                   "name": "optima"
                }
```

**Response**

HTTP/1.1 200 OK

```json
{
   [
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "category_id": 2
    },
    ]
}
```
etc. 

## Testing

Description of how to test code...

Start your debugger and open Postman. Make sure you have an token referenced in the headers and issue a GET request for
http://localhost:8000/products?name=optima&   .  You should see all the Optimas in the database returned in the response. 

## Related Issues

#45 