### PR TITLE
Past orders not displaying

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 from rest_framework import status
 from rest_framework.decorators import action
 from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
+from bangazonapi.views.paymenttype import PaymentSerializer
 from .product import ProductSerializer
 
 
@@ -29,11 +30,23 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    total_cost = serializers.DecimalField(
+        max_digits=10, decimal_places=2, read_only=True
+    )
+    payment_type_info = PaymentSerializer(source="payment_type", read_only=True)
 
     class Meta:
         model = Order
         url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
-        fields = ("id", "url", "created_date", "payment_type", "customer", "lineitems")
+        fields = (
+            "id",
+            "url",
+            "created_date",
+            "payment_type_info",
+            "customer",
+            "lineitems",
+            "total_cost",
+        )
 
 
 class Orders(ViewSet):

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -30,6 +30,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    payment_type_info = PaymentSerializer(source="payment_type", read_only=True)
 
     class Meta:
         model = Order
@@ -38,7 +39,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "url",
             "created_date",
-            "customer",
+            "payment_type_info" "customer",
             "lineitems",
         )
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -30,10 +30,6 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
-    total_cost = serializers.DecimalField(
-        max_digits=10, decimal_places=2, read_only=True
-    )
-    payment_type_info = PaymentSerializer(source="payment_type", read_only=True)
 
     class Meta:
         model = Order
@@ -42,7 +38,6 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "url",
             "created_date",
-            "payment_type_info",
             "customer",
             "lineitems",
         )

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -45,7 +45,6 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "payment_type_info",
             "customer",
             "lineitems",
-            "total_cost",
         )
 
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -1,7 +1,9 @@
 import datetime
 import json
+from urllib import response
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models.payment import Payment
 
 
 class PaymentTests(APITestCase):
@@ -10,13 +12,19 @@ class PaymentTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_create_payment_type(self):
         """
@@ -28,10 +36,10 @@ class PaymentTests(APITestCase):
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today()
+            "create_date": datetime.date.today(),
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -41,3 +49,24 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self, request, pk=None):
+        url = "/delete-payment"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+        }
+
+        try:
+            payment = Payment.objects.get(pk=pk)
+            payment.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except Payment.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
Updated OrderSerializer to include total cost and payment type information.  

## Changes

- Added total_cost to the OrderLineItemSerializer and added some constrictions so that it only displays 10 digits and allows for a decimal place of 2
- Included a PaymentSerializer  to the OrderSerializer to get the payment info
- Added payment_type_info & total_cost fields to the Order model

## Testing

Description of how to test code...

- [ ] Run the debugger and while testing the client side of this ticket