### PR TITLE
Filter products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -295,6 +295,7 @@ class Products(ViewSet):
         number_sold = self.request.query_params.get("number_sold", None)
         min_price = self.request.query_params.get("min_price", None)
         name = self.request.query_params.get("name", None)
+        location = self.request.query_params.get("location", None)
 
         if order is not None:
             order_filter = order
@@ -323,8 +324,11 @@ class Products(ViewSet):
         if min_price is not None:
             products = products.filter(price__gte=min_price)
 
-        if name is not None: 
+        if name is not None:
             products = products.filter(name__icontains=name)
+
+        if location is not None:
+            products = products.filter(location__icontains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
Added location to the list of items retrieved from the query_params within`def list()` in the Product ViewSet to allow products to be filtered by their location.

## Changes

- Added the following line to retrieve the location passed into the query_params of the fetch url:
```python
        location = self.request.query_params.get("location", None)
```
- Added the following conditional to filter the products:
```python
        if location is not None:
            products = products.filter(location__icontains=location)
```

## Requests / Responses

**Request**

GET `/products?location=Paris` Gets a list of all products filtered by location name


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Paris",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "category_id": 2
    },
    {
    // ... additional products with location of Paris
    }
]
```

## Testing

- [ ] Send a request to /products?location={location_name} in postman. A few location name options are: Paris, Workshop, and Berlin. You should receive a list of products filtered by location. 
- [ ] In the app, go to the Products page. Click Filter Products, Filter By Location, and select a location. You should see the list of products update on the page. To quickly verify that they are all of the correct location, you can inspect the first useState in the dev tools to see that each object in the array has the correct location property. 


## Related Issues

- Closes NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#22