### PR TITLE
Test/complete orders

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -10,7 +10,7 @@ from rest_framework.decorators import action
 from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
 from bangazonapi.views.paymenttype import PaymentSerializer
 from .product import ProductSerializer
-
+from bangazonapi.views.customer import CustomerSerializer
 
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for line items"""
@@ -31,7 +31,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     lineitems = OrderLineItemSerializer(many=True)
     payment_type_info = PaymentSerializer(source="payment_type", read_only=True)
-
+    complete_customer = CustomerSerializer(source="customer")
     class Meta:
         model = Order
         url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
@@ -41,6 +41,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "created_date",
             "payment_type_info",
             "customer",
+            "complete_customer",
             "lineitems",
         )
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -2,8 +2,6 @@ import json
 from datetime import date 
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django.db import models
-import urllib.parse
 
 class OrderTests(APITestCase):
     def setUp(self) -> None:
@@ -30,8 +28,8 @@ class OrderTests(APITestCase):
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        self.category = json.loads(response.content)
         response = self.client.post(url, data, format='json')
+        self.category = json.loads(response.content)
 
         # Create a product
         url = "/products"
@@ -244,8 +242,8 @@ class OrderTests(APITestCase):
         url = f"/orders/{self.order["id"]}"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
-        self.customer = json_response["complete_customer"]
         json_response = json.loads(response.content)
+        self.customer = json_response["complete_customer"]
 
         today = str(date.today())
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -225,7 +225,7 @@ class OrderTests(APITestCase):
         # Update order with payment 
 
         today = str(datetime.date.today())
-        now = models.DateField(auto_now_add=True)
+
 
         url = "/orders/1"
         data = { "payment_type": 1 }
@@ -242,11 +242,19 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["customer"], "http://testserver/customers/1")
-        self.assertEqual(json_response["created_date"], now)
+        self.assertEqual(json_response["created_date"], today)
         self.assertEqual(json_response["payment_type_info"]["id"], 1)
+        self.assertEqual(json_response["payment_type_info"]["url"], "http://testserver/paymenttypes/1")
         self.assertEqual(json_response["payment_type_info"]["merchant_name"], "American Express")
         self.assertEqual(json_response["payment_type_info"]["account_number"], "111-1111-1111")
         self.assertEqual(json_response["payment_type_info"]["expiration_date"], "2024-12-31")
         self.assertGreaterEqual(json_response["payment_type_info"]["create_date"], today)
+        self.assertEqual(json_response["lineitems"][0]["id"],  1)
+        self.assertEqual(json_response["lineitems"][0]["product"]["name"],  "Kite")
+        self.assertEqual(json_response["lineitems"][0]["product"]["price"],  14.99)
+        self.assertEqual(json_response["lineitems"][0]["product"]["quantity"],  60)
+        self.assertEqual(json_response["lineitems"][0]["product"]["description"],  "It flies high")
+        self.assertEqual(json_response["lineitems"][0]["product"]["category_id"],  1)
+        self.assertEqual(json_response["lineitems"][0]["product"]["location"],  "Pittsburgh")
 
     # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -36,8 +36,9 @@ class OrderTests(APITestCase):
         data = { "name": "Kite", "price": 14.99, "quantity": 60, "description": "It flies high", "category_id": 1, "location": "Pittsburgh" }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.product = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
 
         url = "/paymenttypes"
         data = {
@@ -226,7 +227,7 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { 'product_id': self.product.id }
+        data = { 'product_id': self.product["id"] }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
 
@@ -236,7 +237,9 @@ class OrderTests(APITestCase):
         url = "/cart"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
+        self.order = json.loads(response.content)
         json_response = json.loads(response.content)
+        
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["id"], 1)
@@ -249,14 +252,14 @@ class OrderTests(APITestCase):
         today = str(datetime.date.today())
 
 
-        url = "/orders/1"
-        data = { "payment_type": self.paymenttype.id} 
+        url = f"/orders/{self.order["id"]}"
+        data = { "payment_type": self.paymenttype["id"]} 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get order and verify payment was added
-        url = "/orders/1"
+        url = f"/orders/{self.order["id"]}"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,8 +1,12 @@
 import json
+<<<<<<< HEAD
 from datetime import date, datetime
+=======
+import datetime
+>>>>>>> cd77490 (lingering-date-issue)
 from rest_framework import status
 from rest_framework.test import APITestCase
-import datetime
+from django.db import models
 
 
 class OrderTests(APITestCase):
@@ -45,7 +49,6 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-<<<<<<< HEAD
         # Create a payment type
         url = "/paymenttypes"
 
@@ -62,25 +65,6 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.paymenttype = json.loads(response.content)
-=======
-        url = "/paymenttypes"
-        data = {
-            "merchant_name": "American Express",
-            "account_number": "111-1111-1111",
-            "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today(),
-        }
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.post(url, data, format="json")
-        json_response = json.loads(response.content)
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(json_response["merchant_name"], "American Express")
-        self.assertEqual(json_response["account_number"], "111-1111-1111")
-        self.assertEqual(json_response["expiration_date"], "2024-12-31")
-        self.assertEqual(json_response["create_date"], str(datetime.date.today()))
-
->>>>>>> 09fa7a2 (a start)
 
     def test_add_product_to_order(self):
         """
@@ -239,6 +223,10 @@ class OrderTests(APITestCase):
         self.test_add_product_to_order()
 
         # Update order with payment 
+
+        today = str(datetime.date.today())
+        now = models.DateField(auto_now_add=True)
+
         url = "/orders/1"
         data = { "payment_type": 1 }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
@@ -252,6 +240,13 @@ class OrderTests(APITestCase):
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["customer"], "http://testserver/customers/1")
+        self.assertEqual(json_response["created_date"], now)
         self.assertEqual(json_response["payment_type_info"]["id"], 1)
+        self.assertEqual(json_response["payment_type_info"]["merchant_name"], "American Express")
+        self.assertEqual(json_response["payment_type_info"]["account_number"], "111-1111-1111")
+        self.assertEqual(json_response["payment_type_info"]["expiration_date"], "2024-12-31")
+        self.assertGreaterEqual(json_response["payment_type_info"]["create_date"], today)
 
     # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -243,7 +243,7 @@ class OrderTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
-        self.customer = json_response["complete_customer"]
+       
 
         today = str(date.today())
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -219,8 +219,25 @@ class OrderTests(APITestCase):
         """
         Ensure we can complete an order by updating the payment.
         """
-        # Add product
-        self.test_add_product_to_order()
+        # Add product to order
+        url = "/cart"
+        data = { "product_id": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was added
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["size"], 1)
+        self.assertEqual(len(json_response["lineitems"]), 1)
+
 
         # Update order with payment 
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,9 +1,5 @@
 import json
-<<<<<<< HEAD
 from datetime import date, datetime
-=======
-import datetime
->>>>>>> cd77490 (lingering-date-issue)
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django.db import models
@@ -37,6 +33,13 @@ class OrderTests(APITestCase):
 
         # Create a product
         url = "/products"
+        data = { "name": "Kite", "price": 14.99, "quantity": 60, "description": "It flies high", "category_id": 1, "location": "Pittsburgh" }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.product = json.loads(response.content)
+
+        url = "/paymenttypes"
         data = {
             "name": "Kite",
             "price": 14.99,
@@ -47,7 +50,9 @@ class OrderTests(APITestCase):
         }
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.paymenttype = json.loads(response.content)
 
         # Create a payment type
         url = "/paymenttypes"
@@ -221,7 +226,7 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { "product_id": 1 }
+        data = { 'product_id': self.product.id }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
 
@@ -245,7 +250,7 @@ class OrderTests(APITestCase):
 
 
         url = "/orders/1"
-        data = { "payment_type": 1 }
+        data = { "payment_type": self.paymenttype.id} 
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/tests/order.py
+++ b/tests/order.py
@@ -2,6 +2,7 @@ import json
 from datetime import date, datetime
 from rest_framework import status
 from rest_framework.test import APITestCase
+import datetime
 
 
 class OrderTests(APITestCase):
@@ -44,6 +45,7 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+<<<<<<< HEAD
         # Create a payment type
         url = "/paymenttypes"
 
@@ -60,6 +62,25 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.paymenttype = json.loads(response.content)
+=======
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today(),
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(json_response["merchant_name"], "American Express")
+        self.assertEqual(json_response["account_number"], "111-1111-1111")
+        self.assertEqual(json_response["expiration_date"], "2024-12-31")
+        self.assertEqual(json_response["create_date"], str(datetime.date.today()))
+
+>>>>>>> 09fa7a2 (a start)
 
     def test_add_product_to_order(self):
         """
@@ -210,3 +231,27 @@ class OrderTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 2)
+    def test_complete_order(self):
+        """
+        Ensure we can complete an order by updating the payment.
+        """
+        # Add product
+        self.test_add_product_to_order()
+
+        # Update order with payment 
+        url = "/orders/1"
+        data = { "payment_type": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get order and verify payment was added
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["payment_type_info"]["id"], 1)
+
+    # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -264,13 +264,12 @@ class OrderTests(APITestCase):
         url = f"/orders/{self.order["id"]}"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
-        customer_url = json_response["customer"]
-        customer_id = int(urllib.parse.urlparse(customer_url).path.split('/')[-1])
+        self.customer = json_response["complete_customer"]
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # self.assertEqual(json_response["customer"], self.customer["id"])
-        self.assertEqual(customer_id, self.customer["id"])
+        self.assertEqual(json_response["complete_customer"]["id"], self.customer["id"])
         self.assertEqual(json_response["created_date"], today)
         self.assertEqual(json_response["payment_type_info"]["id"], self.paymenttype["id"])
         self.assertEqual(json_response["payment_type_info"]["url"], "http://testserver/paymenttypes/1")

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -50,7 +50,6 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
-<<<<<<< HEAD
     def test_delete_payment_type(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         url = "/paymenttypes"
@@ -70,26 +69,3 @@ class PaymentTests(APITestCase):
 
         with self.assertRaises(Payment.DoesNotExist):
             Payment.objects.get(pk=self.paymenttype["id"])
-=======
-    # def test_delete_payment_type(self, request, pk=None):
-    #     url = "/delete-payment"
-    #     data = {
-    #         "merchant_name": "American Express",
-    #         "account_number": "111-1111-1111",
-    #         "expiration_date": "2024-12-31",
-    #     }
-
-    #     try:
-    #         payment = Payment.objects.get(pk=pk)
-    #         payment.delete()
-
-    #         return Response({}, status=status.HTTP_204_NO_CONTENT)
-
-    #     except Payment.DoesNotExist as ex:
-    #         return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-
-    #     except Exception as ex:
-    #         return Response(
-    #             {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-    #         )
->>>>>>> 09fa7a2 (a start)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -50,6 +50,7 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+<<<<<<< HEAD
     def test_delete_payment_type(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         url = "/paymenttypes"
@@ -69,3 +70,26 @@ class PaymentTests(APITestCase):
 
         with self.assertRaises(Payment.DoesNotExist):
             Payment.objects.get(pk=self.paymenttype["id"])
+=======
+    # def test_delete_payment_type(self, request, pk=None):
+    #     url = "/delete-payment"
+    #     data = {
+    #         "merchant_name": "American Express",
+    #         "account_number": "111-1111-1111",
+    #         "expiration_date": "2024-12-31",
+    #     }
+
+    #     try:
+    #         payment = Payment.objects.get(pk=pk)
+    #         payment.delete()
+
+    #         return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    #     except Payment.DoesNotExist as ex:
+    #         return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    #     except Exception as ex:
+    #         return Response(
+    #             {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+    #         )
+>>>>>>> 09fa7a2 (a start)


### PR DESCRIPTION
This pull request includes my test to complete an order by adding a payment type. 

## Changes

- I added a new field to be returned with the get request for a single order. It will return a new field called 'complete-customer' which serializes all the customer data rather than just the url which is still there as the value for the customer field. 
- I created the test to see if an order can be successfully completed. The test issues a put request to add the payment_type id to the order. Then it gets the order and checks all the fields to confirm the payment_type was updated and none of the other fields were affected. 

##Request 
http://localhost:8000/orders/7

##Response
``` json
{
    "id": 7,
    "url": "http://localhost:8000/orders/7",
    "created_date": "2019-05-27",
    "payment_type_info": {
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/2",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi9",
        "expiration_date": "2020-02-01",
        "create_date": "2019-12-12"
    },
    "customer": "http://localhost:8000/customers/6",
    "complete_customer": {
        "id": 6,
        "url": "http://localhost:8000/customers/6",
        "user": {
            "url": "http://localhost:8000/users/7",
            "password": "pbkdf2_sha256$150000$fHDURJBIASpx$trZS1MWc6YiNe5EYNBap+P+zMAwpNgNbUZH/b9bgvdw=",
            "last_login": null,
            "is_superuser": false,
            "username": "jisie",
            "first_name": "Jisie",
            "last_name": "David",
            "email": "jisie@jisiedavid.com",
            "is_staff": false,
            "is_active": true,
            "date_joined": "2019-10-10T22:48:19.899000Z",
            "groups": [],
            "user_permissions": []
        },
        "phone_number": "555-1212",
        "address": "100 Dauntless Way"
    },
    "lineitems": [any line items will appear here]
}
```
## Testing

Run the python3 manage.py test tests -v 1 command. You should see this message after the tests run 

Ran 10 tests in 'x's

OK

## Related Issues

- TEST: Complete order by adding payment type
[#19](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth/issues/19)