### PR TITLE
Update /cart create() status code

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -41,7 +41,11 @@ class Cart(ViewSet):
         line_item.order = open_order
         line_item.save()
 
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+        serialized_order = OrderSerializer(
+            open_order, many=False, context={"request": request}
+        )
+
+        return Response(serialized_order.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, request, pk=None):
         """


### PR DESCRIPTION
When working on the order testing module, I noticed that the `/cart` `create()` method returns a 204 response after a successful post. It is best practice to return HTTP_201_created after a successful post, so I made the appropriate updates to the cart viewset. 

## Changes

- serialized the order to generate the response json (lines 44-46)
- updated the Response to return the serialized order and HTTP_201_CREATED (line 48)

## Requests / Responses

**Request**

POST `/cart` Adds a lineitem to the cart

```json
{
    "product_id": 1
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 9,
    "url": "http://localhost:8000/orders/9",
    "created_date": "2018-12-08",
    "payment_type_info": null,
    "customer": "http://localhost:8000/customers/6",
    "lineitems": [
        {
            "id": 1,
            "product": {
                "id": 1,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0,
                "category_id": 2
            }
        }
    ]
}
```

## Testing

- [ ] Send a post request to `/cart` with `{"product_id": 1}` in the body
- [ ] Verify that you receive a response similar to the example above with a status code of 201
