### PR TITLE
Ak test delete payment

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -3,6 +3,7 @@ import json
 from urllib import response
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import payment
 from bangazonapi.models.payment import Payment
 
 
@@ -49,24 +50,22 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
-    def test_delete_payment_type(self, request, pk=None):
-        url = "/delete-payment"
+    def test_delete_payment_type(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        url = "/paymenttypes"
         data = {
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today(),
         }
+        response = self.client.post(url, data, format="json")
+        self.paymenttype = json.loads(response.content)
 
-        try:
-            payment = Payment.objects.get(pk=pk)
-            payment.delete()
+        url = f"/paymenttypes/{self.paymenttype["id"]}"
 
-            return Response({}, status=status.HTTP_204_NO_CONTENT)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        except Payment.DoesNotExist as ex:
-            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-
-        except Exception as ex:
-            return Response(
-                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        with self.assertRaises(Payment.DoesNotExist):
+            Payment.objects.get(pk=self.paymenttype["id"])


### PR DESCRIPTION
This pull request implements features the feature to delete a payment type.  It includes changes to the API to enable deletion functionality and update relevant endpoints.  Automated tests have been added to ensure the feature works as expected and returns the appropriate response.  

## Changes

- Created a test_delete_payment_type method that creates a test client & payment type
- The creation returns an id that is used to define the url endpoint which creates a specific, unique identifier which is targeted for deletion
- After deletion a response is returned with a "204 no content" to ensure the payment type was, in fact, deleted

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

This is the test model, which is the same we see from the paymenttype viewset:

{
            "merchant_name": "American Express",
            "account_number": "111-1111-1111",
            "expiration_date": "2024-12-31",
            "create_date": datetime.date.today(),
}

**Response**

Ran 8 tests in 4.578s

OK
Destroying test database for alias 'default'...

## Testing

Description of how to test code...

- [ ] From AK-test-delete-payment run python3 manage.py test tests -v 1
- [ ] That is it.  Just make sure the "OK" message is returned