### PR TITLE
Test: New line item is not added to closed order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -98,27 +98,52 @@ class OrderTests(APITestCase):
         """
         When the user has no open orders, ensure that a new order is created when adding the first product rather than associating the product with a previously closed order.
         """
-        # Run test for add product to order
-        self.test_add_product_to_order()
 
-        # Run test for complete order
+        # Establish authorization for the requests to come
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
 
-        # Get orders and verify that len(response) is 1
-        url = "/orders"
-        self.client.credentials(HTTP_AUTHORIZATION="Token" + self.token)
-        response = self.client.get(url, None, format="json")
-        json_response = json.loads(response.content)
+        # Get a product id from the testing database
+        url = "/products"
+        products_response = self.client.get(url, None, format="json")
+        product_list = json.loads(products_response.content)
+        product_id = product_list[0]["id"]
 
-        self.assertEqual(len(json_response), 1)
+        # Add the product to the cart
+        url = "/cart"
+        product_data = {"product_id": product_id}
+        response = self.client.post(url, product_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        print(response)
 
-        # Run test for add product to order again
-        self.test_add_product_to_order()
+        # # Get info about the current open cart
+        # response = self.client.get(url, None, format="json")
+        # first_cart = json.loads(response.content)
+        # first_cart_id = first_cart.id
+        # first_cart_lineitems = first_cart.lineitems
+        # self.assertEqual(len(first_cart_lineitems), 1)
+        # self.assertIsNone(first_cart.payment_type)
 
-        # Get orders and verify that len(response) is 2
-        response = self.client.get(url, None, format="json")
-        json_response = json.loads(response.content)
+        # # Add another product to the cart
+        # self.client.post(url, product_data, format="json")
 
-        self.assertEqual(len(json_response), 2)
-        self.assertIsNotNone(json_response[0].payment_type)
-        # Verify that response[1].payment_type is null
-        self.assertIsNone(json_response[1].payment_type)
+        # # Complete the order
+
+        # # Get orders and verify that len(response) is 1
+        # url = "/orders"
+        # self.client.credentials(HTTP_AUTHORIZATION="Token" + self.token)
+        # response = self.client.get(url, None, format="json")
+        # json_response = json.loads(response.content)
+
+        # self.assertEqual(len(json_response), 1)
+
+        # # Add product to order again
+        # self.test_add_product_to_order()
+
+        # # Get orders and verify that len(response) is 2
+        # response = self.client.get(url, None, format="json")
+        # json_response = json.loads(response.content)
+
+        # self.assertEqual(len(json_response), 2)
+        # self.assertIsNotNone(json_response[0].payment_type)
+        # # Verify that response[1].payment_type is null
+        # self.assertIsNone(json_response[1].payment_type)

--- a/tests/order.py
+++ b/tests/order.py
@@ -114,7 +114,7 @@ class OrderTests(APITestCase):
     # TODO: New line item is not added to closed order
     def test_add_item_to_new_open_order(self):
         """
-        When the user has no open orders, ensure that a new order is created when adding the first product rather than associating the product with a previously closed order.
+        When the user has no open orders, ensure that a new cart is created when adding the first product rather than associating the product with a previously closed order.
         """
 
         # Establish authorization for the requests to come
@@ -138,8 +138,6 @@ class OrderTests(APITestCase):
 
         cart_with_one_item = json.loads(response.content)
         cart_with_one_item_id = cart_with_one_item["id"]
-        cart_with_one_item_lineitems = cart_with_one_item["lineitems"]
-        self.assertEqual(len(cart_with_one_item_lineitems), 1)
         self.assertIsNone(cart_with_one_item["payment_type_info"])
 
         # Add another product to the cart
@@ -152,8 +150,6 @@ class OrderTests(APITestCase):
 
         cart_with_two_items = json.loads(response.content)
         cart_with_two_items_id = cart_with_two_items["id"]
-        cart_with_two_items_lineitems = cart_with_two_items["lineitems"]
-        self.assertEqual(len(cart_with_two_items_lineitems), 2)
         self.assertIsNone(cart_with_one_item["payment_type_info"])
 
         # Verify that the cart id did not change when a second product was added
@@ -184,7 +180,7 @@ class OrderTests(APITestCase):
         # Verify that there are two products on this order
         self.assertEqual(len(json_response[0]["lineitems"]), 2)
 
-        # Verify the payment info
+        # Verify that the payment info matches the paymenttype created in setUp()
         self.assertEqual(json_response[0]["payment_type_info"], self.paymenttype)
 
         # Add a product to cart again. This time, expect a new order to be opened.
@@ -200,6 +196,8 @@ class OrderTests(APITestCase):
         new_cart_with_one_item_id = new_cart_with_one_item["id"]
         new_cart_with_one_item_lineitems = new_cart_with_one_item["lineitems"]
         self.assertEqual(len(new_cart_with_one_item_lineitems), 1)
+
+        # Verify that the new cart has no payment type
         self.assertIsNone(new_cart_with_one_item["payment_type_info"])
 
         # Verify that the first cart and second cart have different id's

--- a/tests/order.py
+++ b/tests/order.py
@@ -77,7 +77,7 @@ class OrderTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Get cart and verify product was added
         url = "/cart"
@@ -136,7 +136,7 @@ class OrderTests(APITestCase):
         url = "/cart"
         product_data = {"product_id": product_id}
         response = self.client.post(url, product_data, format="json")
-        # self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Get info about the current open cart
         response = self.client.get(url, None, format="json")
@@ -146,7 +146,7 @@ class OrderTests(APITestCase):
         cart_with_one_item_id = cart_with_one_item["id"]
         cart_with_one_item_lineitems = cart_with_one_item["lineitems"]
         self.assertEqual(len(cart_with_one_item_lineitems), 1)
-        self.assertIsNone(cart_with_one_item["payment_type"])
+        self.assertIsNone(cart_with_one_item["payment_type_info"])
 
         # Add another product to the cart
         self.client.post(url, product_data, format="json")
@@ -160,7 +160,7 @@ class OrderTests(APITestCase):
         cart_with_two_items_id = cart_with_two_items["id"]
         cart_with_two_items_lineitems = cart_with_two_items["lineitems"]
         self.assertEqual(len(cart_with_two_items_lineitems), 2)
-        self.assertIsNone(cart_with_one_item["payment_type"])
+        self.assertIsNone(cart_with_one_item["payment_type_info"])
 
         # Verify that the cart id has not changed
         self.assertEqual(cart_with_one_item_id, cart_with_two_items_id)

--- a/tests/order.py
+++ b/tests/order.py
@@ -60,12 +60,6 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.paymenttype = json.loads(response.content)
-        self.assertEqual(
-            self.paymenttype["create_date"], date.today().strftime("%Y-%m-%d")
-        )
-        self.assertEqual(self.paymenttype["expiration_date"], exp.strftime("%Y-%m-%d"))
-        self.assertEqual(self.paymenttype["merchant_name"], data["merchant_name"])
-        self.assertEqual(self.paymenttype["account_number"], data["account_number"])
 
     def test_add_product_to_order(self):
         """

--- a/tests/order.py
+++ b/tests/order.py
@@ -9,9 +9,16 @@ class OrderTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -19,16 +26,22 @@ class OrderTests(APITestCase):
         # Create a product category
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
 
         # Create a product
         url = "/products"
-        data = { "name": "Kite", "price": 14.99, "quantity": 60, "description": "It flies high", "category_id": 1, "location": "Pittsburgh" }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        data = {
+            "name": "Kite",
+            "price": 14.99,
+            "quantity": 60,
+            "description": "It flies high",
+            "category_id": 1,
+            "location": "Pittsburgh",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_add_product_to_order(self):
         """
@@ -36,23 +49,22 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { "product_id": 1 }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get cart and verify product was added
         url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.get(url, None, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
-
 
     def test_remove_product_from_order(self):
         """
@@ -63,16 +75,16 @@ class OrderTests(APITestCase):
 
         # Remove product from cart
         url = "/cart/1"
-        data = { "product_id": 1 }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.delete(url, data, format='json')
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get cart and verify product was removed
         url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.get(url, None, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -82,3 +94,31 @@ class OrderTests(APITestCase):
     # TODO: Complete order by adding payment type
 
     # TODO: New line item is not added to closed order
+    def test_add_item_to_new_open_order(self):
+        """
+        When the user has no open orders, ensure that a new order is created when adding the first product rather than associating the product with a previously closed order.
+        """
+        # Run test for add product to order
+        self.test_add_product_to_order()
+
+        # Run test for complete order
+
+        # Get orders and verify that len(response) is 1
+        url = "/orders"
+        self.client.credentials(HTTP_AUTHORIZATION="Token" + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(len(json_response), 1)
+
+        # Run test for add product to order again
+        self.test_add_product_to_order()
+
+        # Get orders and verify that len(response) is 2
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(len(json_response), 2)
+        self.assertIsNotNone(json_response[0].payment_type)
+        # Verify that response[1].payment_type is null
+        self.assertIsNone(json_response[1].payment_type)


### PR DESCRIPTION
## Definitions
First, note that my definition of "cart" throughout this pull request and in the code is an open order that has a payment_type of NULL. 

My definition of "closed order" is an order that has been paid for and completed. 

## Summary
This test checks that the following conditions are followed:
* if there is no cart in the database associated with the user making the request, then a new cart is created when an item is posted to the cart.
* if there is already a cart associated with the user making the request, then the item is posted to the existing cart.
 
This way, a user can only have one active cart at any given time, and new items are never added to already closed orders. 

## Changes

- a payment type was added to `setUp()` and was stored in `self.paymenttype`
- `test_add_item_to_new_open_order()` was implemented in tests/order.py
- Comments were left throughout the test describing my thought process and logic.

## Testing

- [ ] `git checkout` this branch, test/18/add-item-to-open-order, and run the testing command: `python3 manage.py test tests -v 1`
- [ ] You should see 9 tests complete. All tests should pass. 


## Related Issues

- NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#18
- NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#33