### PR TITLE
Report - list completed orders

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path("login", login_user),
     path("api-token-auth", obtain_auth_token),
     path("api-auth", include("rest_framework.urls", namespace="rest_framework")),
-    path("reports/orders", report, name="report"),
+    path("reports/orders", order_reports, name="report"),
     path(
         "reports/expensiveproducts",
         expensive_products_report,

--- a/bangazonapi/templates/index.html
+++ b/bangazonapi/templates/index.html
@@ -1,23 +1,36 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Unpaid Orders Report</title>
+    <title>{{ html.title }}</title>
   </head>
   <body>
-    <h1>Unpaid Orders Report</h1>
+    <h1>{{ html.heading }}</h1>
     <table>
       <tr>
         <th>Order ID</th>
         <th>Customer Name</th>
+        {% if status == "complete" %}
+        <th>Total Paid</th>
+        <th>Payment Type</th>
+        {%else%}
         <th>Total Cost</th>
+        {% endif %}
       </tr>
-      {% for order in report_data %}
+
+      {% if status == "complete" %} {% for order in report_data %}
       <tr>
         <td>{{ order.order_id }}</td>
         <td>{{ order.customer_name }}</td>
-        <td>{{ order.total_cost|floatformat:2 }}</td>
+        <td>${{ order.total_paid|floatformat:2 }}</td>
+        <td>{{ order.payment_type }}</td>
       </tr>
-      {% endfor %}
+      {% endfor %} {% else %} {% for order in report_data %}
+      <tr>
+        <td>{{ order.order_id }}</td>
+        <td>{{ order.customer_name }}</td>
+        <td>${{ order.total_cost|floatformat:2 }}</td>
+      </tr>
+      {% endfor %} {% endif %}
     </table>
   </body>
 </html>

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,4 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
-from .report import report
+from .report import order_reports

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -3,30 +3,72 @@ from bangazonapi.models import Order, Customer, OrderProduct, Product
 from django.contrib.auth.models import User
 
 
-def report(request):
-    unpaid_orders = Order.objects.filter(payment_type=None)
-    report_data = []
+def order_reports(request):
+    status = request.GET.get("status")
+    if status == "incomplete":
+        unpaid_orders = Order.objects.filter(payment_type=None)
+        report_data = []
 
-    for order in unpaid_orders:
-        customer = Customer.objects.get(id=order.customer_id)
-        user = User.objects.get(id=customer.user_id)
-        order_products = OrderProduct.objects.filter(order_id=order.id)
+        for order in unpaid_orders:
+            customer = Customer.objects.get(id=order.customer_id)
+            user = User.objects.get(id=customer.user_id)
+            order_products = OrderProduct.objects.filter(order_id=order.id)
 
-        total_cost = sum(
-            product.price
-            for order_product in order_products
-            for product in Product.objects.filter(id=order_product.product_id)
-        )
+            total_cost = sum(
+                product.price
+                for order_product in order_products
+                for product in Product.objects.filter(id=order_product.product_id)
+            )
 
-        report_data.append(
-            {
+            report_data.append(
+                {
+                    "order_id": order.id,
+                    "customer_name": f"{user.first_name} {user.last_name}",
+                    "total_cost": total_cost,
+                }
+            )
+
+        data = {
+            "status": status,
+            "report_data": report_data,
+            "html": {
+                "title": "Unpaid Orders Report",
+                "heading": "Unpaid Orders Report",
+            },
+        }
+
+        return render(request, "index.html", data)
+
+    if status == "complete":
+
+        completed_orders = Order.objects.filter(payment_type__isnull=False)
+
+        report_data = []
+        for order in completed_orders:
+            lineitems = order.lineitems.all()
+
+            total_cost_of_order = 0
+            for lineitem in lineitems:
+                total_cost_of_order += lineitem.product.price
+
+            table_data = {
                 "order_id": order.id,
-                "customer_name": f"{user.first_name} {user.last_name}",
-                "total_cost": total_cost,
+                "customer_name": f"{order.customer.user.first_name} {order.customer.user.last_name}",
+                "total_paid": total_cost_of_order,
+                "payment_type": order.payment_type.merchant_name,
             }
-        )
+            report_data.append(table_data)
 
-    return render(request, "index.html", {"report_data": report_data})
+        data = {
+            "status": status,
+            "report_data": report_data,
+            "html": {
+                "title": "Completed Orders Report",
+                "heading": "Completed Orders Report",
+            },
+        }
+
+        return render(request, "index.html", data)
 
 
 def expensive_products_report(request):


### PR DESCRIPTION
Created a report that can be accessed in the browser at /reports/orders?status=complete that lists all completed orders. Each row on the report contains:
* order id
* customer name
* total amount paid
* payment info (e.g. Visa, Mastercard)

## Changes

- edited the existing report method to handle different query params. i.e. different data will be produced depending on whether the url contains `?status=complete` or `?status=incomplete`
- edited the `data` object that is output by the order_reports() method. Now it contains keys for `status`, `html`, and `report_data`. These updates were necessary for distinguishing between`?status=complete` and `?status=incomplete` in the index.html template
- implemented the data access and total paid calculations for completed orders


## Testing

While in this branch with the debugger running:

- [ ] Seed the database to take it back to its initial state
- [ ] Go to http://localhost:8000/reports/orders?status=complete
You should see the list of completed orders with their order id, customer name, total amount paid, and payment info.
![image](https://github.com/NSS-Day-Cohort-68/bangazon-api-bangazon-team-5-api-elizabeth/assets/145211725/9975410c-5ee0-4112-a80e-0f64369c4834)

- [ ] Go to http://localhost:8000/reports/orders?status=incomplete
You should see a list of incomplete orders with their order id, customer name, and total cost. 
![image](https://github.com/NSS-Day-Cohort-68/bangazon-api-bangazon-team-5-api-elizabeth/assets/145211725/61de1d7a-533f-49b9-a5e0-8f0c4348da76)



## Related Issues

- Fixes NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#10