### PR TITLE
AK-report-inexpensive-products

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -7,7 +7,10 @@ from bangazonapi.models import *
 from bangazonapi.views import *
 from django.contrib import admin
 
-from bangazonapi.views.report import expensive_products_report
+from bangazonapi.views.report import (
+    expensive_products_report,
+    inexpensive_products_report,
+)
 
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
@@ -35,6 +38,11 @@ urlpatterns = [
         "reports/expensiveproducts",
         expensive_products_report,
         name="expensive_products_report",
+    ),
+    path(
+        "reports/inexpensiveproducts",
+        inexpensive_products_report,
+        name="inexpensive_products_report",
     ),
     path("admin", admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/templates/inexpensive_products_report.html
+++ b/bangazonapi/templates/inexpensive_products_report.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Inexpensive Products Report</title>
+  </head>
+  <body>
+    <h1>Inexpensive Products Report</h1>
+    <table>
+      <tr>
+        <th>Product Id</th>
+        <th>Name</th>
+        <th>Price</th>
+      </tr>
+      {% for product in inexpensive_products %}
+      <tr>
+        <td>{{ product.id }}</td>
+        <td>{{ product.name }}</td>
+        <td>{{ product.price | floatformat:2 }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </body>
+</html>
+</body>
+</html>

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -36,3 +36,12 @@ def expensive_products_report(request):
         "expensive_products_report.html",
         {"expensive_products": expensive_products},
     )
+
+
+def inexpensive_products_report(request):
+    inexpensive_products = Product.objects.filter(price__lte=999)
+    return render(
+        request,
+        "inexpensive_products_report.html",
+        {"inexpensive_products": inexpensive_products},
+    )


### PR DESCRIPTION
This PR addresses ticket  REPORT: Inexpensive products
[#11](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth/issues/11)

to present the client with a report of the products under $999.  When the client accesses a url they will be presented with a list of the product id number, the product name and the price of the product.

## Changes

- In report.py I wrote a method with logic to filter the products less than or equal to 999
- Provided a html template file to provide the appropriate html body to present to the client
- In the urls.py I added the path to the "reports/inexpensiveproducts" url
 
## Requests / Responses

http://localhost:8000/reports/inexpensiveproducts

**Request**

GET `http://localhost:8000/reports/inexpensiveproducts`

**Response**

HTTP/1.1 201 OK

You can either click on the raw tab and see the html body or the preview tab and see a much better, nicer looking, structured view of the report

## Testing

Description of how to test code...

- [ ] Go to postman and make a GET request with http://localhost:8000/reports/inexpensiveproducts in the url
- [ ] In the report.py under the inexpensive_products_report filter put in different prices to make sure it gets all the relevant prices