### PR TITLE
Added store data to ProfileSerializer

### DIFF
--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -5,7 +5,9 @@ from .customer import Customer
 class Store(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField()
-    owner = models.ForeignKey(Customer, on_delete=models.CASCADE, related_name="store")
+    owner = models.OneToOneField(
+        Customer, on_delete=models.CASCADE, related_name="store"
+    )
 
     @property
     def products_sold(self):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -411,6 +411,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "payment_types",
             "recommends",
             "has_store",
+            "store",
         )
         depth = 1
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -395,10 +395,6 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
-    has_store = serializers.SerializerMethodField()
-
-    def get_has_store(self, obj):
-        return Store.objects.filter(owner=obj).exists()
 
     class Meta:
         model = Customer
@@ -410,7 +406,6 @@ class ProfileSerializer(serializers.ModelSerializer):
             "address",
             "payment_types",
             "recommends",
-            "has_store",
             "store",
         )
         depth = 1


### PR DESCRIPTION
After becoming better acquainted with the client-side code, I realized that the profile object needs a store property on it. If the user has no store, profile.store should be null/undefined. If the user has a store, profile.store should contain the nested store details. I updated the ProfileSerializer and Store model to accommodate this change.

## Changes

- Made the owner field in the Store model a OneToOneField
- Added "store" to the list of fields in the ProfileSerialzier
- Removed unnecessary logic from the store create() method

## Requests / Responses

Send a get profile request as Brenda and Steve. Brenda should have a nested store. Steve's store value should be null.

**Request**

GET `/profile` 

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 7,
    "url": "http://localhost:8000/customers/7",
    "user": {
        "first_name": "Brenda",
        "last_name": "Long",
        "email": "brenda@brendalong.com"
    },
    "phone_number": "555-1212",
    "address": "100 Indefatiguable Way",
    "payment_types": [
        {
            "id": 3,
            "deleted": null,
            "deleted_by_cascade": false,
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11",
            "customer": 7
        }
    ],
    "recommends": [],
    "store": {
        "id": 1,
        "name": "Brenda's Boutique",
        "description": "Curated selection of chic fashion essentials and unique accessories, providing personalized style solutions for every occasion.",
        "owner": 7
    }
}
```

## Testing

- [ ] Seed database with .seed_data.sh
- [ ] Send GET request to /profile as Brenda and Steve. Brenda should have a store in the response. Steve's store should be null.

## Related Issues

NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth#14