### PR TITLE
Bugfix: A rating cannot be added to a product #60

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     ),
     path("admin", admin.site.urls),
     path(
-        "products/<int:pk>/rate-product/",
+        "products/<int:pk>/rate-product",
         Products.as_view({"post": "rate_product"}),
         name="rate-product",
     ),

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -46,4 +46,9 @@ urlpatterns = [
         name="inexpensive_products_report",
     ),
     path("admin", admin.site.urls),
+    path(
+        "products/<int:pk>/rate-product/",
+        Products.as_view({"post": "rate_product"}),
+        name="rate-product",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -86,7 +86,7 @@ class Product(SafeDeleteModel):
 
         try:
             avg = total_rating / len(ratings)
-            return avg
+            return round(avg, 1)
         except ZeroDivisionError:
             avg = 0
             return avg

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -353,8 +353,8 @@ class Products(ViewSet):
 
     @action(methods=["post"], detail=True)
     def rate_product(self, request, pk=None):
-        product = self.get_object()
-        rating = request.data.get("rating")
+        # product = self.get_object()
+        # rating = request.data.get("rating")
         # Process the rating data and update the product rating
         # ...
         return Response(None, status=status.HTTP_200_OK)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -350,3 +350,11 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(methods=["post"], detail=True)
+    def rate_product(self, request, pk=None):
+        product = self.get_object()
+        rating = request.data.get("rating")
+        # Process the rating data and update the product rating
+        # ...
+        return Response(None, status=status.HTTP_200_OK)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -2,6 +2,7 @@
 
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation
+from bangazonapi.models.productrating import ProductRating
 import base64
 from django.core.files.base import ContentFile
 from django.http import HttpResponseServerError
@@ -353,8 +354,14 @@ class Products(ViewSet):
 
     @action(methods=["post"], detail=True)
     def rate_product(self, request, pk=None):
-        # product = self.get_object()
-        # rating = request.data.get("rating")
-        # Process the rating data and update the product rating
-        # ...
-        return Response(None, status=status.HTTP_200_OK)
+        if request.method == "POST":
+            product_rating = ProductRating()
+            product_rating.product = Product.objects.get(pk=pk)
+            product_rating.customer = Customer.objects.get(user=request.auth.user)
+            product_rating.rating = request.data["score"]
+
+            product_rating.save()
+
+            return Response(None, status=status.HTTP_200_OK)
+
+        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/tests/order.py
+++ b/tests/order.py
@@ -39,7 +39,6 @@ class OrderTests(APITestCase):
         self.product = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-<<<<<<< HEAD
         # Create a payment type
         url = "/paymenttypes"
 
@@ -87,55 +86,6 @@ class OrderTests(APITestCase):
         data = {"product_id": 1}
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.delete(url, data, format="json")
-=======
-    def test_add_product_to_order(self):
-        """
-        Ensure we can add a product to an order.
-        """
-        # Add product to order
-        url = "/cart"
-        data = {"product_id": 1}
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.post(url, data, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-        # Get cart and verify product was added
-        url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.get(url, None, format="json")
-        json_response = json.loads(response.content)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["id"], 1)
-        self.assertEqual(json_response["size"], 1)
-        self.assertEqual(len(json_response["lineitems"]), 1)
-
-    def test_remove_product_from_order(self):
-        """
-        Ensure we can remove a product from an order.
-        """
-        # Add product
-        self.test_add_product_to_order()
-
-        # Remove product from cart
-        url = "/cart/1"
-        data = {"product_id": 1}
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.delete(url, data, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-        # Get cart and verify product was removed
-        url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.get(url, None, format="json")
-        json_response = json.loads(response.content)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["size"], 0)
-        self.assertEqual(len(json_response["lineitems"]), 0)
->>>>>>> 7e8f8ff (uncommented out order tests)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -39,6 +39,7 @@ class OrderTests(APITestCase):
         self.product = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+<<<<<<< HEAD
         # Create a payment type
         url = "/paymenttypes"
 
@@ -86,6 +87,55 @@ class OrderTests(APITestCase):
         data = {"product_id": 1}
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.delete(url, data, format="json")
+=======
+    def test_add_product_to_order(self):
+        """
+        Ensure we can add a product to an order.
+        """
+        # Add product to order
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was added
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["size"], 1)
+        self.assertEqual(len(json_response["lineitems"]), 1)
+
+    def test_remove_product_from_order(self):
+        """
+        Ensure we can remove a product from an order.
+        """
+        # Add product
+        self.test_add_product_to_order()
+
+        # Remove product from cart
+        url = "/cart/1"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was removed
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["size"], 0)
+        self.assertEqual(len(json_response["lineitems"]), 0)
+>>>>>>> 7e8f8ff (uncommented out order tests)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -74,11 +74,6 @@ class OrderTests(APITestCase):
         response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["id"], 1)
-        self.assertEqual(json_response["size"], 1)
-        self.assertEqual(len(json_response["lineitems"]), 1)
-
     def test_remove_product_from_order(self):
         """
         Ensure we can remove a product from an order.

--- a/tests/product.py
+++ b/tests/product.py
@@ -6,6 +6,18 @@ from bangazonapi.models.product import Product
 from bangazonapi.models.productrating import ProductRating
 
 
+def create_product():
+    return Product.objects.create(
+        name="Test Product",
+        price=1000.00,
+        quantity=2,
+        description="This is a test product",
+        category_id=1,
+        location="Narnia",
+        customer_id=1,
+    )
+
+
 class ProductTests(APITestCase):
     def setUp(self) -> None:
         """
@@ -39,15 +51,7 @@ class ProductTests(APITestCase):
         """
         Create test product
         """
-        self.product = Product.objects.create(
-            name="Test Product",
-            price=1000.00,
-            quantity=2,
-            description="This is a test product",
-            category_id=1,
-            location="Narnia",
-            customer_id=1,
-        )
+        self.product = create_product()
 
     def test_create_product(self):
         """
@@ -106,9 +110,9 @@ class ProductTests(APITestCase):
         """
         Ensure we can get a collection of products.
         """
-        self.test_create_product()
-        self.test_create_product()
-        self.test_create_product()
+        create_product()
+        create_product()
+        create_product()
 
         product_count = Product.objects.count()
 
@@ -120,15 +124,6 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), product_count)
 
     def test_delete_product(self):
-        product = Product.objects.create(
-            name="Test Product",
-            price=10.00,
-            description="Test description",
-            quantity=20,
-            category_id=1,
-            location="Anytown, usa",
-            customer_id=1,
-        )
         url = f"/products/1"
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)

--- a/tests/product.py
+++ b/tests/product.py
@@ -137,30 +137,30 @@ class ProductTests(APITestCase):
 
     # TODO: Product can be rated. Assert average rating exists.
 
-    def test_avg_rating(self):
-        # self.test_create_product()
-        # url = "/products"
-        # data = {
-        #     "name": "Kite",
-        #     "price": 14.99,
-        #     "quantity": 60,
-        #     "description": "It flies high",
-        #     "category_id": 1,
-        #     "location": "Pittsburgh",
-        # }
-        # response = self.client.post(url, data, format="json")
+    # def test_avg_rating(self):
+    # self.test_create_product()
+    # url = "/products"
+    # data = {
+    #     "name": "Kite",
+    #     "price": 14.99,
+    #     "quantity": 60,
+    #     "description": "It flies high",
+    #     "category_id": 1,
+    #     "location": "Pittsburgh",
+    # }
+    # response = self.client.post(url, data, format="json")
 
-        # setup - create product
+    # setup - create product
 
-        # can you add a rating to a product?
-        product_rating = 3
-        self.productrating = ProductRating.objects.create(
-            product_id=self.product.id,
-            customer_id=self.product.customer_id,
-            rating=product_rating,
-        )
+    # can you add a rating to a product?
+    # product_rating = 3
+    # self.productrating = ProductRating.objects.create(
+    #     product_id=self.product.id,
+    #     customer_id=self.product.customer_id,
+    #     rating=product_rating,
+    # )
 
-        # self.assertEqual(self.productrating.count(), 1)
-        # does the avg_rating key exist?
+    # self.assertEqual(self.productrating.count(), 1)
+    # does the avg_rating key exist?
 
-        # does the avg_rating work?
+    # does the avg_rating work?

--- a/tests/product.py
+++ b/tests/product.py
@@ -110,12 +110,14 @@ class ProductTests(APITestCase):
         self.test_create_product()
         self.test_create_product()
 
+        product_count = Product.objects.count()
+
         url = "/products"
 
         response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(json_response), 4)
+        self.assertEqual(len(json_response), product_count)
 
     def test_delete_product(self):
         product = Product.objects.create(

--- a/tests/product.py
+++ b/tests/product.py
@@ -35,19 +35,19 @@ class ProductTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["name"], "Sporting Goods")
-    
-        """
-        Create test product
-        """
-        data = {
-            "name": "Test Product",
-            "price": 1000.00,
-            "quantity": 2,
-            "description": "This is a test product",
-            "category_id": 1,
-            "location": "Narnia",
-        }
-        self.product = Product.objects.create(data, format="json")
+
+        # """
+        # Create test product
+        # """
+        # data = {
+        #     "name": "Test Product",
+        #     "price": 1000.00,
+        #     "quantity": 2,
+        #     "description": "This is a test product",
+        #     "category_id": 1,
+        #     "location": "Narnia",
+        # }
+        # self.product = Product.objects.create(data)
 
     def test_create_product(self):
         """
@@ -140,23 +140,23 @@ class ProductTests(APITestCase):
 
     # TODO: Product can be rated. Assert average rating exists.
 
-    def test_avg_rating(self):
-        # self.test_create_product()
-        # url = "/products"
-        # data = {
-        #     "name": "Kite",
-        #     "price": 14.99,
-        #     "quantity": 60,
-        #     "description": "It flies high",
-        #     "category_id": 1,
-        #     "location": "Pittsburgh",
-        # }
-        # response = self.client.post(url, data, format="json")
+    # def test_avg_rating(self):
+    # self.test_create_product()
+    # url = "/products"
+    # data = {
+    #     "name": "Kite",
+    #     "price": 14.99,
+    #     "quantity": 60,
+    #     "description": "It flies high",
+    #     "category_id": 1,
+    #     "location": "Pittsburgh",
+    # }
+    # response = self.client.post(url, data, format="json")
 
-        # setup - create product
+    # setup - create product
 
-        # can you add a rating to a product?
+    # can you add a rating to a product?
 
-        # does the avg_rating key exist?
+    # does the avg_rating key exist?
 
-        # does the avg_rating work?
+    # does the avg_rating work?

--- a/tests/product.py
+++ b/tests/product.py
@@ -3,6 +3,7 @@ import datetime
 from rest_framework import status
 from rest_framework.test import APITestCase
 from bangazonapi.models.product import Product
+from bangazonapi.models.productrating import ProductRating
 
 
 class ProductTests(APITestCase):
@@ -127,5 +128,14 @@ class ProductTests(APITestCase):
     # TODO: Product can be rated. Assert average rating exists.
 
     def test_avg_rating(self):
-        
-
+        self.test_create_product()
+        url = "/products"
+        data = {
+            "name": "Kite",
+            "price": 14.99,
+            "quantity": 60,
+            "description": "It flies high",
+            "category_id": 1,
+            "location": "Pittsburgh",
+        }
+        response = self.client.post(url, data, format="json")

--- a/tests/product.py
+++ b/tests/product.py
@@ -36,18 +36,18 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["name"], "Sporting Goods")
 
-        # """
-        # Create test product
-        # """
-        # data = {
-        #     "name": "Test Product",
-        #     "price": 1000.00,
-        #     "quantity": 2,
-        #     "description": "This is a test product",
-        #     "category_id": 1,
-        #     "location": "Narnia",
-        # }
-        # self.product = Product.objects.create(data)
+        """
+        Create test product
+        """
+        self.product = Product.objects.create(
+            name="Test Product",
+            price=1000.00,
+            quantity=2,
+            description="This is a test product",
+            category_id=1,
+            location="Narnia",
+            customer_id=1,
+        )
 
     def test_create_product(self):
         """
@@ -115,7 +115,7 @@ class ProductTests(APITestCase):
         response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(json_response), 3)
+        self.assertEqual(len(json_response), 4)
 
     def test_delete_product(self):
         product = Product.objects.create(
@@ -136,22 +136,22 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         with self.assertRaises(Product.DoesNotExist):
-            Product.objects.get(id=product.id)
+            Product.objects.get(id=self.product.id)
 
     # TODO: Product can be rated. Assert average rating exists.
 
     # def test_avg_rating(self):
-    # self.test_create_product()
-    # url = "/products"
-    # data = {
-    #     "name": "Kite",
-    #     "price": 14.99,
-    #     "quantity": 60,
-    #     "description": "It flies high",
-    #     "category_id": 1,
-    #     "location": "Pittsburgh",
-    # }
-    # response = self.client.post(url, data, format="json")
+    #     self.test_create_product()
+    #     url = "/products"
+    #     data = {
+    #         "name": "Kite",
+    #         "price": 14.99,
+    #         "quantity": 60,
+    #         "description": "It flies high",
+    #         "category_id": 1,
+    #         "location": "Pittsburgh",
+    #     }
+    #     response = self.client.post(url, data, format="json")
 
     # setup - create product
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -137,23 +137,30 @@ class ProductTests(APITestCase):
 
     # TODO: Product can be rated. Assert average rating exists.
 
-    # def test_avg_rating(self):
-    #     self.test_create_product()
-    #     url = "/products"
-    #     data = {
-    #         "name": "Kite",
-    #         "price": 14.99,
-    #         "quantity": 60,
-    #         "description": "It flies high",
-    #         "category_id": 1,
-    #         "location": "Pittsburgh",
-    #     }
-    #     response = self.client.post(url, data, format="json")
+    def test_avg_rating(self):
+        # self.test_create_product()
+        # url = "/products"
+        # data = {
+        #     "name": "Kite",
+        #     "price": 14.99,
+        #     "quantity": 60,
+        #     "description": "It flies high",
+        #     "category_id": 1,
+        #     "location": "Pittsburgh",
+        # }
+        # response = self.client.post(url, data, format="json")
 
-    # setup - create product
+        # setup - create product
 
-    # can you add a rating to a product?
+        # can you add a rating to a product?
+        product_rating = 3
+        self.productrating = ProductRating.objects.create(
+            product_id=self.product.id,
+            customer_id=self.product.customer_id,
+            rating=product_rating,
+        )
 
-    # does the avg_rating key exist?
+        # self.assertEqual(self.productrating.count(), 1)
+        # does the avg_rating key exist?
 
-    # does the avg_rating work?
+        # does the avg_rating work?

--- a/tests/product.py
+++ b/tests/product.py
@@ -35,6 +35,19 @@ class ProductTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["name"], "Sporting Goods")
+    
+        """
+        Create test product
+        """
+        data = {
+            "name": "Test Product",
+            "price": 1000.00,
+            "quantity": 2,
+            "description": "This is a test product",
+            "category_id": 1,
+            "location": "Narnia",
+        }
+        self.product = Product.objects.create(data, format="json")
 
     def test_create_product(self):
         """
@@ -128,14 +141,22 @@ class ProductTests(APITestCase):
     # TODO: Product can be rated. Assert average rating exists.
 
     def test_avg_rating(self):
-        self.test_create_product()
-        url = "/products"
-        data = {
-            "name": "Kite",
-            "price": 14.99,
-            "quantity": 60,
-            "description": "It flies high",
-            "category_id": 1,
-            "location": "Pittsburgh",
-        }
-        response = self.client.post(url, data, format="json")
+        # self.test_create_product()
+        # url = "/products"
+        # data = {
+        #     "name": "Kite",
+        #     "price": 14.99,
+        #     "quantity": 60,
+        #     "description": "It flies high",
+        #     "category_id": 1,
+        #     "location": "Pittsburgh",
+        # }
+        # response = self.client.post(url, data, format="json")
+
+        # setup - create product
+
+        # can you add a rating to a product?
+
+        # does the avg_rating key exist?
+
+        # does the avg_rating work?

--- a/tests/product.py
+++ b/tests/product.py
@@ -125,3 +125,7 @@ class ProductTests(APITestCase):
             Product.objects.get(id=product.id)
 
     # TODO: Product can be rated. Assert average rating exists.
+
+    def test_avg_rating(self):
+        
+


### PR DESCRIPTION
This pull request outlines changes that I have made to the API codebase to allow a user to add a rating to a product. 

## Changes

in urls.py...
- I have added a url path for products/pk/rate-product
- This url path will direct the request to the rate_product definition in the Product class under views/product.py

In views/product.py...
- I added a rate_product definition
- This definition will build a product rating based off of the ProductRating model, and save it to the database

In models/product.py...
- I updated the average_rating definition so that the avg is returned as a number rounded to the 1st decimal place. 

_Please ignore the changes that I have made on the tests/product.py for now. I will finish working on this on the next ticket_

## Testing

Description of how to test code...

- [ ] make sure your debugger is running is your API
- [ ] In Postman, make sure that you have a relevant Authorization Token in your headers
- [ ] In Postman, create a POST request with the following http address and json body: 
```
http://localhost:8000/products/11/rate-product
```
``` json
{
    "score": 4,
    "review": "Test Review"
}
```
- [ ] check your bangazonapi_productrating table to ensure the information was added to the database. You should also get a 200 response in Postman. 


## Related Issues

Bugfix: A rating cannot be added to a product
[#60](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth/issues/60)

## Things to Note:

- Currently, the review text is not being saved anywhere in the database. Only the rating number is being saved in the bangazonapi_productrating table
- the bangazonapi_rating table is not being used. Should this be removed from the database?