### PR TITLE
TEST: Product can be rated. Assert average rating exists. #15

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -378,7 +378,7 @@ class Products(ViewSet):
 
             product_rating.save()
 
-            return Response(None, status=status.HTTP_200_OK)
+            return Response(None, status=status.HTTP_201_CREATED)
 
     @action(methods=["post", "delete", "get"], detail=True)
     def like(self, request, pk=None):

--- a/tests/product.py
+++ b/tests/product.py
@@ -53,6 +53,8 @@ class ProductTests(APITestCase):
         """
         self.product = create_product()
 
+        self.customer_id = 6
+
     def test_create_product(self):
         """
         Ensure we can create a new product.
@@ -137,30 +139,37 @@ class ProductTests(APITestCase):
 
     # TODO: Product can be rated. Assert average rating exists.
 
-    # def test_avg_rating(self):
-    # self.test_create_product()
-    # url = "/products"
-    # data = {
-    #     "name": "Kite",
-    #     "price": 14.99,
-    #     "quantity": 60,
-    #     "description": "It flies high",
-    #     "category_id": 1,
-    #     "location": "Pittsburgh",
-    # }
-    # response = self.client.post(url, data, format="json")
+    def test_avg_rating(self):
 
-    # setup - create product
+        # can you add a rating to a product?
+        rating_url = f"/products/{self.product.id}/rate-product"
 
-    # can you add a rating to a product?
-    # product_rating = 3
-    # self.productrating = ProductRating.objects.create(
-    #     product_id=self.product.id,
-    #     customer_id=self.product.customer_id,
-    #     rating=product_rating,
-    # )
+        rating_data = {
+            "score": 3,
+        }
 
-    # self.assertEqual(self.productrating.count(), 1)
-    # does the avg_rating key exist?
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(rating_url, rating_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    # does the avg_rating work?
+        # on a product, does the avg_rating key exist?
+        product_url = f"/products/{self.product.id}"
+
+        # product_data = {
+        #     "name": self.product.name,
+        #     "price": self.product.price,
+        #     "quantity": self.product.quantity,
+        #     "description": self.product.quantity,
+        #     "category_id": self.product.category_id,
+        #     "location": self.product.location,
+        #     "customer_id": self.product.customer_id,
+        # }
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(product_url, None, format="json")
+        json_response = json.loads(response.content)
+
+        print("avg rating", json_response["average_rating"])
+        self.assertEqual(json_response["average_rating"], 3)
+
+        # on a product, is the avg_rating correct?

--- a/tests/product.py
+++ b/tests/product.py
@@ -149,27 +149,29 @@ class ProductTests(APITestCase):
         }
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.post(rating_url, rating_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        add_rating_response = self.client.post(rating_url, rating_data, format="json")
+        self.assertEqual(add_rating_response.status_code, status.HTTP_201_CREATED)
 
         # on a product, does the avg_rating key exist?
         product_url = f"/products/{self.product.id}"
 
-        # product_data = {
-        #     "name": self.product.name,
-        #     "price": self.product.price,
-        #     "quantity": self.product.quantity,
-        #     "description": self.product.quantity,
-        #     "category_id": self.product.category_id,
-        #     "location": self.product.location,
-        #     "customer_id": self.product.customer_id,
-        # }
-
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.get(product_url, None, format="json")
-        json_response = json.loads(response.content)
-
-        print("avg rating", json_response["average_rating"])
-        self.assertEqual(json_response["average_rating"], 3)
+        rating_exist_response = self.client.get(product_url, None, format="json")
+        json_response = json.loads(rating_exist_response.content)
+        res_avg_rating = json_response["average_rating"]
+        # print("avg rating", res_avg_rating)
+        self.assertEqual(bool(res_avg_rating), True)
 
         # on a product, is the avg_rating correct?
+        # add another rating
+        rating_one_data = {
+            "score": 4,
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        self.client.post(rating_url, rating_one_data, format="json")
+        # is the avg_rating correct?
+        get = self.client.get(product_url, None, format="json")
+        res = json.loads(get.content)
+        average_rating = res["average_rating"]
+        print("average_rating", average_rating)
+        self.assertEqual(average_rating, 3.5)


### PR DESCRIPTION
**do not review yet, need to rebase with Will's changes

This PR modifies the tests/product.py module to removes instances where tests are referenced inside other tests. This PR also adds a test_avg_rating. 

## Changes
In views/product.py..
- Under the rate_product definition, I updated the response status to be 201 created, rather than 200 OK

In tests/product.py..
- I created a create_product definition, and created a product in the setup
- I removed instances where tests were referenced inside other tests, and I replaced it with the newly created create_product definition
- I created the test_avg_rating definition. This test ensures we can rate a product, the avg_rating key exists, and the avg_rating is correct

## Testing

Description of how to test code...

- [ ] switch to the tests/avg-rating branch
- [ ] run the following command in your terminal: 
```
python3 manage.py test tests -v 1
```
- [ ] You should see the following result in your terminal:
```
Found 11 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...........
----------------------------------------------------------------------
Ran 11 tests in 2.076s

OK
Destroying test database for alias 'default'...
```
## Related Issues

-TEST: Product can be rated. Assert average rating exists.
[#15](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth/issues/15)